### PR TITLE
Fix split value key bug

### DIFF
--- a/store/dhash/dhash.go
+++ b/store/dhash/dhash.go
@@ -123,9 +123,16 @@ func CreateValueKey(pid peer.ID, ctxID []byte) []byte {
 
 // SplitValueKey splits value key into original components
 func SplitValueKey(valKey []byte) (peer.ID, []byte, error) {
-	pid, err := peer.IDFromBytes(valKey)
+	// Extract multihiash from the value key before converting it to peer.ID.
+	// Extracting peer.ID directly would fail the length check. There is no overhead in doing that as
+	// none of the operations allocates new memory.
+	l, mh, err := multihash.MHFromBytes(valKey)
 	if err != nil {
 		return "", nil, err
 	}
-	return pid, valKey[pid.Size():], nil
+	pid, err := peer.IDFromBytes(mh)
+	if err != nil {
+		return "", nil, err
+	}
+	return pid, valKey[l:], nil
 }


### PR DESCRIPTION
The way that `peer.ID` was extracted before caused length verification failure [here](https://github.com/multiformats/go-multihash/blob/master/multihash.go#L237). Use `MHFromBytes`  to read multihash code / length and set a correct length to the slice. Then us `IDFromBytes` over it that performs all other validations.  