### PR TITLE
Add dhstore latency metrics

### DIFF
--- a/engine/engine.go
+++ b/engine/engine.go
@@ -246,10 +246,12 @@ func (e *Engine) storeDH(ctx context.Context, value indexer.Value, mhs []multiha
 		return err
 	}
 
+	start := time.Now()
 	err = e.sendDHMetadata(ctx, metaReq)
 	if err != nil {
 		return err
 	}
+	stats.Record(context.Background(), metrics.DHMetadataLatency.M(metrics.MsecSince(start)))
 
 	var mergeCount int
 	merges := make([]dhstore.Merge, 0, e.dhBatchSize)
@@ -334,10 +336,12 @@ func (e *Engine) sendDHMerges(ctx context.Context, merges []dhstore.Merge) error
 
 	req.Header.Set("Content-Type", "application/json")
 
+	start := time.Now()
 	rsp, err := e.httpClient.Do(req)
 	if err != nil {
 		return err
 	}
+	stats.Record(context.Background(), metrics.DHMultihashLatency.M(metrics.MsecSince(start)))
 	defer rsp.Body.Close()
 
 	if rsp.StatusCode != http.StatusAccepted {

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -26,6 +26,9 @@ var (
 	IngestMultihashes = stats.Int64("core/ingest_multihashes", "Number of multihashes put into the indexer", stats.UnitDimensionless)
 	RemovedProviders  = stats.Int64("core/removed_providers", "Number of providers removed from indexer", stats.UnitDimensionless)
 	StoreSize         = stats.Int64("core/storage_size", "Bytes of storage used to store the indexed content", stats.UnitBytes)
+
+	DHMultihashLatency = stats.Float64("core/dh_multihash_latency", "Time that the indexer spends on sending encrypted multihashes to dhstore", stats.UnitMilliseconds)
+	DHMetadataLatency  = stats.Float64("core/dh_metadata_latency", "Time that the indexer spends on sending encrypted metadata to dhstore", stats.UnitMilliseconds)
 )
 
 // Views
@@ -72,6 +75,16 @@ var (
 		Measure:     StoreSize,
 		Aggregation: view.LastValue(),
 	}
+
+	dhMultihashLatency = &view.View{
+		Measure:     DHMultihashLatency,
+		Aggregation: view.Distribution(0, 1, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100, 200, 300, 400, 500, 1000, 2000, 5000),
+	}
+
+	dhMetadataLatency = &view.View{
+		Measure:     DHMetadataLatency,
+		Aggregation: view.Distribution(0, 1, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100, 200, 300, 400, 500, 1000, 2000, 5000),
+	}
 )
 
 // DefaultViews with all views in it.
@@ -86,6 +99,8 @@ var DefaultViews = []*view.View{
 	ingestMultihashesView,
 	removedProvidersView,
 	storeSizeView,
+	dhMultihashLatency,
+	dhMetadataLatency,
 }
 
 func MsecSince(startTime time.Time) float64 {


### PR DESCRIPTION
Add PUT multihashes and PUT metadata latency so that we can correlate them with what we observe in dhstore. That will help us to tweak optimal batch size for double hashed ingestion.