### PR TITLE
Update dhstore metrics distribution

### DIFF
--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -78,12 +78,12 @@ var (
 
 	dhMultihashLatency = &view.View{
 		Measure:     DHMultihashLatency,
-		Aggregation: view.Distribution(0, 1, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100, 200, 300, 400, 500, 1000, 2000, 5000),
+		Aggregation: view.Distribution(0, 10, 20, 50, 70, 100, 200, 300, 400, 500, 1000, 2000, 3000, 5000, 7000, 10_000, 30_000, 60_000),
 	}
 
 	dhMetadataLatency = &view.View{
 		Measure:     DHMetadataLatency,
-		Aggregation: view.Distribution(0, 1, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100, 200, 300, 400, 500, 1000, 2000, 5000),
+		Aggregation: view.Distribution(0, 10, 20, 50, 70, 100, 200, 300, 400, 500, 1000, 2000, 3000, 5000, 7000, 10_000, 30_000, 60_000),
 	}
 )
 


### PR DESCRIPTION
Update dhstore metrics distribution buckets as some requests take longer than 5s to complete and  hence get cut off