### PR TITLE
Add dhstore metadata delete

### DIFF
--- a/engine/option.go
+++ b/engine/option.go
@@ -11,11 +11,12 @@ const defaultHttpTimeout = 5 * time.Second
 
 // config contains all options for configuring Engine.
 type config struct {
-	cacheOnPut        bool
-	dhBatchSize       int
-	dhstoreURL        string
-	vsNoNewMH         bool
-	httpClientTimeout time.Duration
+	cacheOnPut         bool
+	dhBatchSize        int
+	dhstoreURL         string
+	dhstoreClusterURLs []string
+	vsNoNewMH          bool
+	httpClientTimeout  time.Duration
 }
 
 type Option func(*config) error
@@ -65,6 +66,29 @@ func WithDHStore(dhsURL string) Option {
 			}
 			c.dhstoreURL = u.String()
 		}
+		return nil
+	}
+}
+
+// WithDHStoreCluster provide addional URLs that the core will send delete requests to.
+// Deletes will be send to the dhstoreURL as well as to all dhstoreClusterURLs. This is required as deletes need to be applied to all nodes until
+// consistent hashing is implemented. dhstoreURL shouldn't be included in this list.
+func WithDHStoreCluster(clusterUrls []string) Option {
+	return func(c *config) error {
+		if len(clusterUrls) == 0 {
+			return nil
+		}
+		urls := make([]string, 0, len(clusterUrls))
+		for _, clusterURL := range clusterUrls {
+			if clusterURL != "" {
+				u, err := url.Parse(clusterURL)
+				if err != nil {
+					return err
+				}
+				urls = append(urls, u.String())
+			}
+		}
+		c.dhstoreClusterURLs = urls
 		return nil
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,10 @@ require (
 	lukechampine.com/blake3 v1.1.7
 )
 
-require github.com/ipni/go-libipni v0.0.0-20230330175745-8950ad3901cc
+require (
+	github.com/ipni/go-libipni v0.0.0-20230330175745-8950ad3901cc
+	github.com/mr-tron/base58 v1.2.0
+)
 
 require (
 	github.com/DataDog/zstd v1.4.5 // indirect
@@ -48,7 +51,6 @@ require (
 	github.com/mattn/go-isatty v0.0.17 // indirect
 	github.com/matttproud/golang_protobuf_extensions v1.0.4 // indirect
 	github.com/minio/sha256-simd v1.0.0 // indirect
-	github.com/mr-tron/base58 v1.2.0 // indirect
 	github.com/multiformats/go-base32 v0.1.0 // indirect
 	github.com/multiformats/go-base36 v0.2.0 // indirect
 	github.com/multiformats/go-multiaddr v0.8.0 // indirect

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -79,11 +79,13 @@ var (
 	dhMultihashLatency = &view.View{
 		Measure:     DHMultihashLatency,
 		Aggregation: view.Distribution(0, 10, 20, 50, 70, 100, 200, 300, 400, 500, 1000, 2000, 3000, 5000, 7000, 10_000, 30_000, 60_000),
+		TagKeys:     []tag.Key{Method},
 	}
 
 	dhMetadataLatency = &view.View{
 		Measure:     DHMetadataLatency,
 		Aggregation: view.Distribution(0, 10, 20, 50, 70, 100, 200, 300, 400, 500, 1000, 2000, 3000, 5000, 7000, 10_000, 30_000, 60_000),
+		TagKeys:     []tag.Key{Method},
 	}
 )
 


### PR DESCRIPTION
* Add a new configuration parameter to provide a list of DHstore cluster urls. DHstore cluster urls are required as delete requests need to be sent to all DHstore nodes even if they are read only;
* Send metadata delete requests to all DHStore nodes;
* Report http method alongside DHStore-related metrics.