### PR TITLE
Remove key-sharding logic

### DIFF
--- a/engine/option.go
+++ b/engine/option.go
@@ -7,18 +7,14 @@ import (
 )
 
 const (
-	defaultDHBatchSize        = 4096
-	defaultDHKeyShard         = false
-	defaultDHShardConcurrency = 128
-	defaultHttpTimeout        = 5 * time.Second
+	defaultDHBatchSize = 4096
+	defaultHttpTimeout = 5 * time.Second
 )
 
 // config contains all options for configuring Engine.
 type config struct {
 	cacheOnPut         bool
 	dhBatchSize        int
-	dhKeyShard         bool
-	dhShardConcurrency int
 	dhstoreURL         string
 	dhstoreClusterURLs []string
 	vsNoNewMH          bool
@@ -30,10 +26,8 @@ type Option func(*config) error
 // getOpts creates a config and applies Options to it.
 func getOpts(opts []Option) (config, error) {
 	cfg := config{
-		dhBatchSize:        defaultDHBatchSize,
-		dhKeyShard:         defaultDHKeyShard,
-		dhShardConcurrency: defaultDHShardConcurrency,
-		httpClientTimeout:  defaultHttpTimeout,
+		dhBatchSize:       defaultDHBatchSize,
+		httpClientTimeout: defaultHttpTimeout,
 	}
 
 	for i, opt := range opts {
@@ -63,26 +57,6 @@ func WithDHBatchSize(size int) Option {
 	}
 }
 
-// WithDHKeyShard enables/disabled the dhstore key sharding for the core. When
-// key sharding is enabled (on by default), a shard key is included with each
-// metadata put request, and a seperate merge request with a shard key is sent
-// for each multihash. Context delete requests are also sent with a shard key.
-func WithDHKeyShard(enabled bool) Option {
-	return func(c *config) error {
-		c.dhKeyShard = enabled
-		return nil
-	}
-}
-
-func WithDHShardConcurrency(n int) Option {
-	return func(c *config) error {
-		if n > 0 {
-			c.dhShardConcurrency = n
-		}
-		return nil
-	}
-}
-
 // WithDHStore sets the base URL for the dhstore service, and tells the core to
 // send its values to the dhstore.
 func WithDHStore(dhsURL string) Option {
@@ -98,9 +72,11 @@ func WithDHStore(dhsURL string) Option {
 	}
 }
 
-// WithDHStoreCluster provide addional URLs that the core will send delete requests to.
-// Deletes will be send to the dhstoreURL as well as to all dhstoreClusterURLs. This is required as deletes need to be applied to all nodes until
-// consistent hashing is implemented. dhstoreURL shouldn't be included in this list.
+// WithDHStoreCluster provide addional URLs that the core will send delete
+// requests to. Deletes are send to the dhstoreURL as well as to all
+// dhstoreClusterURLs. This is required as deletes need to be applied to all
+// nodes until consistent hashing is implemented. dhstoreURL must not be
+// included in this list.
 func WithDHStoreCluster(clusterUrls []string) Option {
 	return func(c *config) error {
 		if len(clusterUrls) == 0 {


### PR DESCRIPTION
We will not be splitting each request to dhstore into thousands of separate multihash requests. 