### PR TITLE
Remove WITHVSNoNewMH option

### DIFF
--- a/engine/engine.go
+++ b/engine/engine.go
@@ -41,7 +41,6 @@ type Engine struct {
 	dhMetaURL        string
 	dhMetaDeleteURLs []string
 	httpClient       http.Client
-	vsNoNewMH        bool
 }
 
 var _ indexer.Interface = &Engine{}
@@ -89,7 +88,6 @@ func New(resultCache cache.Interface, valueStore indexer.Interface, options ...O
 		dhMetaURL:        dhMetaURL,
 		dhMetaDeleteURLs: dhMetaDeleteURLs,
 
-		vsNoNewMH:  opts.vsNoNewMH,
 		httpClient: httpClient,
 	}
 }
@@ -220,21 +218,15 @@ func (e *Engine) Put(value indexer.Value, mhs ...multihash.Multihash) error {
 		e.updateCacheStats()
 	}
 
-	var err error
-
 	if e.valueStore != nil {
-		if e.vsNoNewMH {
-			err = e.valueStore.Put(value)
-		} else {
-			err = e.valueStore.Put(value, mhs...)
-		}
+		err := e.valueStore.Put(value, mhs...)
 		if err != nil {
 			return err
 		}
 	}
 
 	if e.dhMergeURL != "" {
-		err = e.storeDH(context.Background(), value, mhs)
+		err := e.storeDH(context.Background(), value, mhs)
 		if err != nil {
 			return err
 		}

--- a/engine/option.go
+++ b/engine/option.go
@@ -17,7 +17,6 @@ type config struct {
 	dhBatchSize        int
 	dhstoreURL         string
 	dhstoreClusterURLs []string
-	vsNoNewMH          bool
 	httpClientTimeout  time.Duration
 }
 
@@ -93,16 +92,6 @@ func WithDHStoreCluster(clusterUrls []string) Option {
 			}
 		}
 		c.dhstoreClusterURLs = urls
-		return nil
-	}
-}
-
-// WithVSNoNewMH blocks putting new multihashes into the value store when set
-// to true. New indexes will still be send to the DHStore service if one is
-// configured.
-func WithVSNoNewMH(ok bool) Option {
-	return func(c *config) error {
-		c.vsNoNewMH = ok
 		return nil
 	}
 }


### PR DESCRIPTION
That was for when we started putting data in dhstore, but most of the previous data was in the local pebble store.  We did not want to add any new data to pebble, and wanted all the new data going to dhstore. At the same time, we wanted deletes and metadata updates reflected in the existing pebble data. We no longer need this.