### PR TITLE
Implement Remove for dhstore

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,16 +56,11 @@ import (
 func main() {
 	// Configuration values.
 	const valueStoreDir = "/tmp/indexvaluestore"
-	const storeType = "sth"
 	const cacheSize = 65536
 
 	// Create value store of configured type.
 	os.Mkdir(valueStoreDir, 0770)
-	var valueStore indexer.Interface
-	var err error
-	if storeType == "pebble" {
-		valueStore, err = pebble.New(valueStoreDir, nil)
-	}
+    valueStore, err := pebble.New(valueStoreDir, nil)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/store/dhstore/option.go
+++ b/store/dhstore/option.go
@@ -7,13 +7,13 @@ import (
 )
 
 const (
-	defaultDHBatchSize = 4096
+	defaultBatchSize   = 4096
 	defaultHttpTimeout = 5 * time.Second
 )
 
 // config contains all options for configuring Engine.
 type config struct {
-	dhBatchSize        int
+	batchSize          int
 	dhstoreClusterURLs []string
 	httpClientTimeout  time.Duration
 }
@@ -23,7 +23,7 @@ type Option func(*config) error
 // getOpts creates a config and applies Options to it.
 func getOpts(opts []Option) (config, error) {
 	cfg := config{
-		dhBatchSize:       defaultDHBatchSize,
+		batchSize:         defaultBatchSize,
 		httpClientTimeout: defaultHttpTimeout,
 	}
 
@@ -40,7 +40,7 @@ func getOpts(opts []Option) (config, error) {
 func WithDHBatchSize(size int) Option {
 	return func(c *config) error {
 		if size > 0 {
-			c.dhBatchSize = size
+			c.batchSize = size
 		}
 		return nil
 	}


### PR DESCRIPTION
Implement the Remove function of the core interface for dhstore. This allows removal of double-hashed index values stored in dhstore.

Other minor changes:
- Renamed internal variables to remove unneeded dh prefix
- Update README to remove reference to sth