### PR TITLE
Do metadata deletes concurrently

### DIFF
--- a/version.json
+++ b/version.json
@@ -1,3 +1,3 @@
 {
-  "version": "v0.8.5"
+  "version": "v0.8.6"
 }


### PR DESCRIPTION
If there is a non-context error, retry the specific dhstore that had an error. This helps avoid a retry for all dhstores.